### PR TITLE
Remove Exadria quest

### DIFF
--- a/OnInit.lua
+++ b/OnInit.lua
@@ -11,7 +11,7 @@ aura_env.dragon_isles_general = {
 aura_env.dragon_isles_obsidian_citadel = {
     {name = "Allegiance to One", quests = {66419}},
     {name = "Talonstalker Kavia Quests", quests = {69918, 66633, 65842, 66103}, completed_on = 2},
-    {name = "Exadria Quests", quests = {67099, 66445, 66321, 66449, 67142, 69984}, completed_on = 2},
+    {name = "Exadria Quests", quests = {67099, 66445, 66321, 66449, 67142}, completed_on = 2},
     {name = "Stoker Volrax Quest", quests = {66308, 66326}},
     --Wrathion
     {name = "Keys of Loyalty", quests = {66133}, required_quests = {66802}},


### PR DESCRIPTION
The quest doesn't count towards Exadria's two weekly quests. It's in the same category as:
https://www.wowhead.com/quest=69983
https://www.wowhead.com/quest=66883
There are also 2 dailies similar to these 3 weeklies:
https://www.wowhead.com/quest=66882
https://www.wowhead.com/quest=70848

@vozochris Can you take a look?